### PR TITLE
Add validators

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,11 @@
     "php": "^8.1",
     "doctrine/doctrine-fixtures-bundle": "^3.4",
     "doctrine/orm": "^2.13",
+    "egulias/email-validator": "^3.0|^4.0",
     "nelmio/security-bundle": "^2.8 || ^3.0",
     "sentry/sentry-symfony": "^4.9",
     "symfony/apache-pack": "^1.0",
+    "symfony/form": "^5.4|^6.2",
     "symfony/framework-bundle": "^5.4|^6.2",
     "theofidry/alice-data-fixtures": "^1.5"
   },

--- a/src/Utils/DateUtils.php
+++ b/src/Utils/DateUtils.php
@@ -41,7 +41,7 @@ class DateUtils
 
     public static function getMonthChoices(string $locale = 'fr_FR'): array
     {
-        $formatter = new \IntlDateFormatter(locale: $locale, pattern: 'MMMM');
+        $formatter = new \IntlDateFormatter(locale: $locale, dateType: \IntlDateFormatter::FULL, timeType: \IntlDateFormatter::FULL, pattern: 'MMMM');
         for ($i = 1; $i <= 12; $i++) {
             $month = $formatter->format(strtotime("2000-$i")); // @phpstan-ignore-line MDT the year is arbitrary and does not impact the month
             $toReturn[ucfirst((string) $month)] = $i;
@@ -52,7 +52,7 @@ class DateUtils
 
     public static function monthYearToString(?int $month = null, ?int $year = null, string $locale = 'fr_FR'): ?string
     {
-        $formatter = new \IntlDateFormatter(locale: $locale, pattern: 'MMMM');
+        $formatter = new \IntlDateFormatter(locale: $locale, dateType: \IntlDateFormatter::FULL, timeType: \IntlDateFormatter::FULL, pattern: 'MMMM');
         if ($month !== null && $year !== null) {
             $month = $formatter->format(strtotime("$year-$month")); // @phpstan-ignore-line
             return ucfirst((string) $month) . ' ' . $year;

--- a/src/Validator/Constraints/EmailChain.php
+++ b/src/Validator/Constraints/EmailChain.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Smart\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY"})
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class EmailChain extends Constraint
+{
+    public string $message = 'email_chain.format_error';
+
+    /** @var non-empty-string */
+    public string $separator;
+
+    /**
+     * @param non-empty-string $separator
+     */
+    public function __construct(
+        mixed $options = null,
+        array $groups = null,
+        mixed $payload = null,
+        string $separator = ','
+    ) {
+        parent::__construct($options, $groups, $payload);
+
+        $this->separator = $separator;
+    }
+}

--- a/src/Validator/Constraints/EmailChainValidator.php
+++ b/src/Validator/Constraints/EmailChainValidator.php
@@ -27,6 +27,7 @@ class EmailChainValidator extends ConstraintValidator
         $validator = Validation::createValidator();
         foreach ($emailToValidate as $email) {
             // MDT add strict mode https://github.com/symfony/symfony/issues/35307
+            // Need egulias/email-validator dependency for use in strict mode
             $violations = $validator->validate(trim($email), [new Email(['mode' => Email::VALIDATION_MODE_STRICT])]);
             if ($violations->count() > 0 || trim($email) === '') {
                 $this->context->buildViolation($constraint->message)->addViolation();

--- a/src/Validator/Constraints/EmailChainValidator.php
+++ b/src/Validator/Constraints/EmailChainValidator.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Smart\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Validation;
+
+class EmailChainValidator extends ConstraintValidator
+{
+    /**
+     * @param mixed $value
+     */
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof EmailChain) {
+            throw new UnexpectedTypeException($constraint, EmailChain::class);
+        }
+
+        if ($value === null) {
+            return;
+        }
+
+        $emailToValidate = explode($constraint->separator, $value);
+        $validator = Validation::createValidator();
+        foreach ($emailToValidate as $email) {
+            // MDT add strict mode https://github.com/symfony/symfony/issues/35307
+            $violations = $validator->validate(trim($email), [new Email(['mode' => Email::VALIDATION_MODE_STRICT])]);
+            if ($violations->count() > 0 || trim($email) === '') {
+                $this->context->buildViolation($constraint->message)->addViolation();
+                break;
+            }
+        }
+    }
+}

--- a/src/Validator/Constraints/FileRequiredOnNew.php
+++ b/src/Validator/Constraints/FileRequiredOnNew.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Smart\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY"})
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class FileRequiredOnNew extends Constraint
+{
+    public string $message = 'This value should not be blank.';
+}

--- a/src/Validator/Constraints/FileRequiredOnNewValidator.php
+++ b/src/Validator/Constraints/FileRequiredOnNewValidator.php
@@ -19,6 +19,7 @@ class FileRequiredOnNewValidator extends ConstraintValidator
         }
 
         $object = $this->context->getObject();
+        // Need symfony/form dependency
         if ($object instanceof FormInterface) { // MDT adjust if use the contraints from collection
             $object = $object->getParent()->getData();
         }

--- a/src/Validator/Constraints/FileRequiredOnNewValidator.php
+++ b/src/Validator/Constraints/FileRequiredOnNewValidator.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Smart\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class FileRequiredOnNewValidator extends ConstraintValidator
+{
+    /**
+     * @param mixed $value
+     */
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof FileRequiredOnNew) {
+            throw new UnexpectedTypeException($constraint, FileRequiredOnNew::class);
+        }
+
+        $object = $this->context->getObject();
+        if ($object instanceof FormInterface) { // MDT adjust if use the contraints from collection
+            $object = $object->getParent()->getData();
+        }
+
+        if ($object !== null && $object->getId() === null && $object->getFile() === null) {
+            $this->context->buildViolation($constraint->message)
+                ->atPath('file')
+                ->addViolation();
+        }
+    }
+}

--- a/src/Validator/Constraints/IsModulo.php
+++ b/src/Validator/Constraints/IsModulo.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Smart\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY"})
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class IsModulo extends Constraint
+{
+    public string $message = 'is_modulo.error';
+
+    public int $modulo;
+
+    public function __construct(
+        int $modulo,
+        mixed $options = null,
+        array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct($options, $groups, $payload);
+
+        $this->modulo = $modulo;
+    }
+}

--- a/src/Validator/Constraints/IsModuloValidator.php
+++ b/src/Validator/Constraints/IsModuloValidator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Smart\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class IsModuloValidator extends ConstraintValidator
+{
+    /**
+     * @param mixed $value
+     */
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof IsModulo) {
+            throw new UnexpectedTypeException($constraint, IsModulo::class);
+        }
+
+        if ($value != null && $value % $constraint->modulo !== 0) {
+            $this->context->buildViolation($constraint->message, ['%modulo%' => $constraint->modulo])->addViolation();
+        }
+    }
+}

--- a/src/Validator/Constraints/IsPasswordSafe.php
+++ b/src/Validator/Constraints/IsPasswordSafe.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Smart\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY"})
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class IsPasswordSafe extends Constraint
+{
+    public string $lengthMessage = 'is_password_safe.length_error';
+    public string $missingLowerCharacterMessage = 'is_password_safe.missing_lower_character_error';
+    public string $missingUpperCharacterMessage = 'is_password_safe.missing_upper_character_error';
+    public string $missingNumberMessage = 'is_password_safe.missing_number_error';
+}

--- a/src/Validator/Constraints/IsPasswordSafeValidator.php
+++ b/src/Validator/Constraints/IsPasswordSafeValidator.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Smart\CoreBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * https://site.infocom94.fr/_attachment/articles-mars-2016-actualite-3-3/NP_MDP_NoteTech.pdf
+ */
+class IsPasswordSafeValidator extends ConstraintValidator
+{
+    protected const MINIMAL_STRING_LENGTH = 10;
+    protected const COINTANS_LOWER_CHARACTER_REGEX = '/[a-z]+/';
+    protected const COINTANS_UPPER_CHARACTER_REGEX = '/[A-Z]+/';
+    protected const COINTANS_NUMBER_REGEX = '/[0-9]+/';
+
+    /**
+     * @param mixed $value
+     * @param Constraint $constraint
+     *
+     * @return void
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof IsPasswordSafe) {
+            throw new UnexpectedTypeException($constraint, IsPasswordSafe::class);
+        }
+
+        // custom constraints should ignore null and empty values to allow
+        // other constraints (NotBlank, NotNull, etc.) take care of that
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        if (strlen($value) < self::MINIMAL_STRING_LENGTH) {
+            $this->context->buildViolation($constraint->lengthMessage)->addViolation();
+        }
+
+        if (!preg_match(self::COINTANS_LOWER_CHARACTER_REGEX, $value, $matches)) {
+            $this->context->buildViolation($constraint->missingLowerCharacterMessage)->addViolation();
+        }
+
+        if (!preg_match(self::COINTANS_UPPER_CHARACTER_REGEX, $value, $matches)) {
+            $this->context->buildViolation($constraint->missingUpperCharacterMessage)->addViolation();
+        }
+
+        if (!preg_match(self::COINTANS_NUMBER_REGEX, $value, $matches)) {
+            $this->context->buildViolation($constraint->missingNumberMessage)->addViolation();
+        }
+    }
+}

--- a/tests/Validator/Constraints/EmailChainValidatorTest.php
+++ b/tests/Validator/Constraints/EmailChainValidatorTest.php
@@ -35,7 +35,7 @@ class EmailChainValidatorTest extends AbstractValidatorTest
         return [
             'extension missing' => ["missing@extension"],
             'at missing' => ["missing_arobase.fr"],
-            'first error and second fail' => ["first@ok.fr,second@fail"],
+            'first valid and second fail' => ["first@ok.fr,second@fail"],
         ];
     }
 

--- a/tests/Validator/Constraints/EmailChainValidatorTest.php
+++ b/tests/Validator/Constraints/EmailChainValidatorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Smart\CoreBundle\Tests\Validator\Constraints;
+
+use Smart\CoreBundle\Validator\Constraints\EmailChain;
+use Smart\CoreBundle\Validator\Constraints\EmailChainValidator;
+use Smart\StandardBundle\Validator\Constraints\AbstractValidatorTest;
+
+/**
+ * vendor/bin/simple-phpunit tests/Validator/Constraints/EmailChainValidatorTest.php
+ */
+class EmailChainValidatorTest extends AbstractValidatorTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getValidatorInstance()
+    {
+        return new EmailChainValidator();
+    }
+
+    /**
+     * @dataProvider failProvider
+     */
+    public function testValidationFail(string $value): void
+    {
+        $constraint = new EmailChain();
+        $validator = $this->initValidator('email_chain.format_error');
+
+        $validator->validate($value, $constraint);
+    }
+
+    public function failProvider(): array
+    {
+        return [
+            'extension missing' => ["missing@extension"],
+            'at missing' => ["missing_arobase.fr"],
+            'first error and second fail' => ["first@ok.fr,second@fail"],
+        ];
+    }
+
+    /**
+     * @dataProvider validProvider
+     */
+    public function testValidationOk(string $value): void
+    {
+        $constraint = new EmailChain();
+        $validator = $this->initValidator();
+
+        $validator->validate($value, $constraint);
+    }
+
+    public function validProvider(): array
+    {
+        return [
+            'simple valid email' => ["test@valid.fr"],
+            'multiple valid email' => ["test1@valid.fr,test2@valid.fr"],
+            'multiple valid email with space' => ["  test1@valid.fr  ,  test2@valid.fr  "],
+        ];
+    }
+}

--- a/tests/Validator/Constraints/IsModuloValidatorTest.php
+++ b/tests/Validator/Constraints/IsModuloValidatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Smart\CoreBundle\Tests\Validator\Constraints;
+
+use Smart\CoreBundle\Validator\Constraints\IsModulo;
+use Smart\CoreBundle\Validator\Constraints\IsModuloValidator;
+use Smart\StandardBundle\Validator\Constraints\AbstractValidatorTest;
+
+/**
+ * vendor/bin/simple-phpunit tests/Validator/Constraints/IsModuloValidatorTest.php
+ */
+class IsModuloValidatorTest extends AbstractValidatorTest
+{
+    private const INVALID_MESSAGE = 'is_modulo.error';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getValidatorInstance()
+    {
+        return new IsModuloValidator();
+    }
+
+    /**
+     * @dataProvider failProvider
+     */
+    public function testValidationFail(int $value): void
+    {
+        $constraint = new IsModulo(15);
+        $validator = $this->initValidator(self::INVALID_MESSAGE);
+
+        $validator->validate($value, $constraint);
+    }
+
+    public function failProvider(): array
+    {
+        return [
+            '1' => [1],
+            '5' => [5],
+            '14' => [14],
+            '16' => [16],
+            '44' => [44],
+            '46' => [46],
+        ];
+    }
+
+    /**
+     * @dataProvider validProvider
+     */
+    public function testValidationOk(int $value): void
+    {
+        $constraint = new IsModulo(15);
+        $validator = $this->initValidator();
+
+        $validator->validate($value, $constraint);
+    }
+
+    public function validProvider(): array
+    {
+        return [
+            '0' => [0],
+            '15' => [15],
+            '30' => [30],
+            '120' => [120],
+        ];
+    }
+}

--- a/tests/Validator/Constraints/IsPasswordSafeValidatorTest.php
+++ b/tests/Validator/Constraints/IsPasswordSafeValidatorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Smart\CoreBundle\Tests\Validator\Constraints;
+
+use Smart\CoreBundle\Validator\Constraints\IsPasswordSafe;
+use Smart\CoreBundle\Validator\Constraints\IsPasswordSafeValidator;
+use Smart\StandardBundle\Validator\Constraints\AbstractValidatorTest;
+
+/**
+ * vendor/bin/simple-phpunit tests/Validator/Constraints/IsPasswordSafeValidatorTest.php
+ */
+class IsPasswordSafeValidatorTest extends AbstractValidatorTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getValidatorInstance()
+    {
+        return new IsPasswordSafeValidator();
+    }
+
+    /**
+     * Test not valid password
+     * @param string $value
+     * @param string $expectedMessage
+     * @dataProvider failPasswordProvider
+     */
+    public function testValidationFail($value, $expectedMessage): void
+    {
+        $constraint = new IsPasswordSafe();
+        $validator = $this->initValidator($expectedMessage);
+
+        $validator->validate($value, $constraint);
+    }
+
+    /**
+     * @return array
+     */
+    public function failPasswordProvider()
+    {
+        return [
+            ["too_SH0RT", "is_password_safe.length_error"],
+            ["0MISSING_LOWER", "is_password_safe.missing_lower_character_error"],
+            ["0missing_upper", "is_password_safe.missing_upper_character_error"],
+            ["missing_NUMBER", "is_password_safe.missing_number_error"],
+        ];
+    }
+
+    /**
+     * Test valid password
+     * @param string $value
+     * @dataProvider validPasswordProvider
+     */
+    public function testValidationOk($value): void
+    {
+        $constraint = new IsPasswordSafe();
+        $validator = $this->initValidator();
+
+        $validator->validate($value, $constraint);
+    }
+
+    /**
+     * @return array
+     */
+    public function validPasswordProvider()
+    {
+        return [
+            ["Aa12345678"],
+            ["MySuperC00lPassword"],
+        ];
+    }
+}

--- a/tests/Validator/Constraints/RegexValidatorTest.php
+++ b/tests/Validator/Constraints/RegexValidatorTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Smart\CoreBundle\Tests\Validator\Constraints;
+
+use Smart\CoreBundle\Utils\RegexUtils;
+use Smart\StandardBundle\Validator\Constraints\AbstractValidatorTest;
+use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\RegexValidator;
+
+/**
+ * vendor/bin/simple-phpunit tests/Validator/Constraints/RegexValidatorTest.php
+ */
+class RegexValidatorTest extends AbstractValidatorTest
+{
+    private const INVALID_MESSAGE = 'This value is not valid.';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getValidatorInstance()
+    {
+        return new RegexValidator();
+    }
+
+    /**
+     * @dataProvider validPhoneProvider
+     */
+    public function testValidRegexPhone(string $value): void
+    {
+        $constraint = new Regex(['pattern' => RegexUtils::PHONE_PATTERN]);
+        $validator = $this->initValidator();
+
+        $validator->validate($value, $constraint);
+    }
+
+    public function validPhoneProvider(): array
+    {
+        return [
+            'concatenated number ' => ["0601020304"],
+            'number with dial code without space' => ["+330601020304"],
+        ];
+    }
+
+    /**
+     * @dataProvider unvalidPhoneProvider
+     */
+    public function testUnvalidRegexPhone(string $value): void
+    {
+        $constraint = new Regex(['pattern' => RegexUtils::PHONE_PATTERN]);
+        $validator = $this->initValidator(self::INVALID_MESSAGE);
+
+        $validator->validate($value, $constraint);
+    }
+
+    public function unvalidPhoneProvider(): array
+    {
+        return [
+            'number missing' => ["06 01 02 03 0"],
+            'to much number' => ["06 01 02 03 04 5"],
+            'number with space' => ["06 01 02 03 04"],
+            'number with dash' => ["06-01-02-03-04"],
+            'number with point' => ["06.01.02.03.04"],
+            'number with separator combination' => ["0601 02-03.04"],
+            'grouping of digits other than 2' => ["060 102 0304"],
+            'missing + for dialing code' => ["330601020304"],
+            'number with dial code with space' => ["+33 06 01 02 03 04"],
+        ];
+    }
+
+    /**
+     * @dataProvider validPostalCodeProvider
+     */
+    public function testValidRegexPostalCode(string $value): void
+    {
+        $constraint = new Regex(['pattern' => RegexUtils::POSTAL_CODE_PATTERN]);
+        $validator = $this->initValidator();
+
+        $validator->validate($value, $constraint);
+    }
+
+    public function validPostalCodeProvider(): array
+    {
+        return [
+            'normal code' => ["26780"],
+            'code with 0 at the beginning' => ["07400"],
+            'code with first 0 optional' => ["7400"],
+        ];
+    }
+
+    /**
+     * @dataProvider unvalidPostalCodeProvider
+     */
+    public function testUnvalidRegexPostalCode(string $value): void
+    {
+        $constraint = new Regex(['pattern' => RegexUtils::POSTAL_CODE_PATTERN]);
+        $validator = $this->initValidator(self::INVALID_MESSAGE);
+
+        $validator->validate($value, $constraint);
+    }
+
+    public function unvalidPostalCodeProvider(): array
+    {
+        return [
+            'number missing' => ["123"],
+            'to much number' => ["123456"],
+            'only 0' => ["00000"],
+            'only 0 version 4 number' => ["0000"],
+            'double 00 at the beginning and sequence of numbers' => ["00123"],
+        ];
+    }
+}


### PR DESCRIPTION
- Add `egulias/email-validator` dependency because `Symfony\Component\Validator\Constraints\Email` need it : `Symfony\Component\Validator\Exception\LogicException: The "egulias/email-validator" component is required to use the "Symfony\Component\Validator\Constraints\Email" constraint in strict mode`
- Add `symfony/form` dependency because `FileRequiredOnNewValidator` need it (`if ($object instanceof FormInterface) {`)