### PR TITLE
Adjust dependencies to allow `doctrine/orm` ^v3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
                     '8.3',
                     '8.4'
                 ]
+                orm: ['2.19.*', '^3.0'] # must be working on both
         container:
             image: ghcr.io/${{ github.repository_owner }}/symfony-docker:php${{ matrix.php }}
             credentials:
@@ -23,6 +24,9 @@ jobs:
                 uses: actions/checkout@v4
             -   name: Configure GitHub token for Composer
                 run: composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
+            # Dynamically update composer.json dependencies before running make install
+            -   name: "Restrict Doctrine ORM version"
+                run: composer require "doctrine/orm:${{ matrix.orm }}" --no-update --no-interaction
             -   name: "Install: vendor & clear cache"
                 run: make install
             -   name: Run coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ CHANGELOG for 1.x
 ### Added
 - Allow orm 3
 - Add composer require dev `symfony/var-exporter` to fix orm v3 qualimetry
+- Add orm v2.19 and v3 matrix to github actions
 
 ### Changed
-- orm minimal version to 2.14 for use of new constant in `GroupConcat`
+- orm minimal version to 2.19 for use of new constant in `GroupConcat`
 
 ### Fixed
 - `GroupConcat` Change use of deprecated constant to use new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG for 1.x
 ## v1.18.0 - (2026-05-15)
 ### Added
 - Allow orm 3
+- Add composer require dev `symfony/var-exporter` to fix orm v3 qualimetry
 
 ### Changed
 - orm minimal version to 2.14 for use of new constant in `GroupConcat`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 CHANGELOG for 1.x
 ===================
+
+## v1.18.0 - (2026-05-15)
+### Added
+- Allow orm 3
+
+### Changed
+- orm minimal version to 2.14 for use of new constant in `GroupConcat`
+
+### Fixed
+- `GroupConcat` Change use of deprecated constant to use new
+
 ## v1.17.1 - (2026-04-16)
 ### Fixed
-- `ProcessStatusEnum::addQbOrderBy` : Switch to inline param to prevent nb binding param due to the BaseEntityProvider resetDQLPart onorderBy 
+- `ProcessStatusEnum::addQbOrderBy` : Switch to inline param to prevent nb binding param due to the BaseEntityProvider resetDQLPart onorderBy
 
 ## v1.17.0 - (2026-02-25)
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^8.1",
     "doctrine/doctrine-fixtures-bundle": "^3.4",
-    "doctrine/orm": "^2.14|^3.0",
+    "doctrine/orm": "^2.19|^3.0",
     "egulias/email-validator": "^3.0|^4.0",
     "nelmio/security-bundle": "^2.8 || ^3.0",
     "sentry/sentry-symfony": "^4.9 || ^5.1",
@@ -27,7 +27,7 @@
     "theofidry/alice-data-fixtures": "^1.5"
   },
   "require-dev": {
-    "smartbooster/standard-bundle": "^1.0",
+    "smartbooster/standard-bundle": "dev-allow_doctrine_orm_v3",
     "symfony/flex": "^2",
     "symfony/phpunit-bridge": "^5.4|^6.2|^7.0",
     "symfony/runtime": "^5.4|^6.2|^7.4",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "theofidry/alice-data-fixtures": "^1.5"
   },
   "require-dev": {
-    "smartbooster/standard-bundle": "dev-allow_doctrine_orm_v3",
+    "smartbooster/standard-bundle": "^1.0",
     "symfony/flex": "^2",
     "symfony/phpunit-bridge": "^5.4|^6.2|^7.0",
     "symfony/runtime": "^5.4|^6.2|^7.4",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^8.1",
     "doctrine/doctrine-fixtures-bundle": "^3.4",
-    "doctrine/orm": "^2.13",
+    "doctrine/orm": "^2.14|^3.0",
     "egulias/email-validator": "^3.0|^4.0",
     "nelmio/security-bundle": "^2.8 || ^3.0",
     "sentry/sentry-symfony": "^4.9 || ^5.1",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     "symfony/flex": "^2",
     "symfony/phpunit-bridge": "^5.4|^6.2|^7.0",
     "symfony/runtime": "^5.4|^6.2|^7.4",
-    "symfony/twig-bundle": "^5.4|^6.2|^7.4"
+    "symfony/twig-bundle": "^5.4|^6.2|^7.4",
+    "symfony/var-exporter": "^5.4|^6.2|^7.4"
   },
   "autoload": {
     "psr-4": {

--- a/src/Query/MySQL/GroupConcat.php
+++ b/src/Query/MySQL/GroupConcat.php
@@ -4,12 +4,10 @@ namespace Smart\CoreBundle\Query\MySQL;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\OrderByClause;
-use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
-/**
- * Allows you to add the MySQL group_concat function to DQL
- * Based on https://github.com/beberlei/DoctrineExtensions/blob/master/src/Query/Mysql/GroupConcat.php
- */
 class GroupConcat extends FunctionNode
 {
     /** @var bool */
@@ -24,61 +22,61 @@ class GroupConcat extends FunctionNode
     /** @var OrderByClause|null */
     public $orderBy = null;
 
-    public function parse(\Doctrine\ORM\Query\Parser $parser): void
+    public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $lexer = $parser->getLexer();
-        if ($lexer->isNextToken(Lexer::T_DISTINCT)) {
-            $parser->match(Lexer::T_DISTINCT);
+        if ($lexer->isNextToken(TokenType::T_DISTINCT)) {
+            $parser->match(TokenType::T_DISTINCT);
 
             $this->isDistinct = true;
         }
 
         // first Path Expression is mandatory
         $this->pathExp = [];
-        if ($lexer->isNextToken(Lexer::T_IDENTIFIER)) {
+        if ($lexer->isNextToken(TokenType::T_IDENTIFIER)) {
             $this->pathExp[] = $parser->StringExpression();
         } else {
             $this->pathExp[] = $parser->SingleValuedPathExpression();
         }
 
-        while ($lexer->isNextToken(Lexer::T_COMMA)) {
-            $parser->match(Lexer::T_COMMA);
+        while ($lexer->isNextToken(TokenType::T_COMMA)) {
+            $parser->match(TokenType::T_COMMA);
             $this->pathExp[] = $parser->StringPrimary();
         }
 
-        if ($lexer->isNextToken(Lexer::T_ORDER)) {
+        if ($lexer->isNextToken(TokenType::T_ORDER)) {
             $this->orderBy = $parser->OrderByClause();
         }
 
-        if ($lexer->isNextToken(Lexer::T_IDENTIFIER)) {
-            $lookaheadValue = is_array($lexer->lookahead) ? $lexer->lookahead['value'] : $lexer->lookahead->value; // @phpstan-ignore-line
-            if (strtolower($lookaheadValue) !== 'separator') {
+        if ($lexer->isNextToken(TokenType::T_IDENTIFIER)) {
+            if (strtolower($lexer->lookahead->value) !== 'separator') {
                 $parser->syntaxError('separator');
             }
-            $parser->match(Lexer::T_IDENTIFIER);
+
+            $parser->match(TokenType::T_IDENTIFIER);
 
             $this->separator = $parser->StringPrimary();
         }
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
-    public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker): string
+    public function getSql(SqlWalker $sqlWalker): string
     {
         $result = 'GROUP_CONCAT(' . ($this->isDistinct ? 'DISTINCT ' : '');
 
         $fields = [];
         foreach ($this->pathExp as $pathExp) {
-            $fields[] = $pathExp->dispatch($sqlWalker); // qa: Faux positif @phpstan-ignore method.nonObject
+            $fields[] = $pathExp->dispatch($sqlWalker); // @phpstan-ignore-line method.nonObject
         }
 
         $result .= sprintf('%s', implode(', ', $fields));
 
         if ($this->orderBy) {
-            $result .= ' ' . $sqlWalker->walkOrderByClause($this->orderBy); // phpcs:ignore
+            $result .= ' ' . $sqlWalker->walkOrderByClause($this->orderBy);  // phpcs:ignore PHPCS_SecurityAudit.Drupal7.DynQueries.D7DynQueriesDirectVar
         }
 
         if ($this->separator) {


### PR DESCRIPTION
Waiting https://github.com/getsentry/sentry-symfony/issues/806 to being fixed before allowing doctrine/orm ^v3.0.

It is related to a fatal error trigger by TracingStatementForV3 which doesn't work properly with doctrine/dbal v4 (which is require by doctrine/orm ^v3.0)