### PR TITLE
Fix process duration calculation in milliseconds instead of seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 CHANGELOG for 1.x
 ===================
+## v1.2.4 - (2024-04-22)
+
+**The process duration value is now calculated in milliseconds instead of seconds.**  
+So update your databases values accordingly when updating to this version.  
+We added new function to the interface to get the value in seconds if you don't care about milliseconds.
+
+### Fixed
+- `ProcessMonitor::end` duration calculation in milliseconds instead of seconds.
+
+### Added
+- `ProcessInterface::getDurationSeconds` + `ProcessInterface::getDurationSecondsAsString` to still manage process duration in seconds.
+- `DateUtils::millisecondsToString` that adds up the number of milliseconds to the string, only if the value is less than a minute.
+
 ## v1.2.3 - (2024-04-18)
 ### Added
 - `StringUtils::upperAccentuatedCharacter` + tests

--- a/src/Entity/ProcessInterface.php
+++ b/src/Entity/ProcessInterface.php
@@ -30,6 +30,10 @@ interface ProcessInterface
 
     public function getDurationAsString(): ?string;
 
+    public function getDurationSeconds(): ?int;
+
+    public function getDurationSecondsAsString(): ?string;
+
     public function setDuration(?int $duration): static;
 
     public function getStatus(): ?ProcessStatusEnum;

--- a/src/Entity/ProcessTrait.php
+++ b/src/Entity/ProcessTrait.php
@@ -38,11 +38,11 @@ trait ProcessTrait
     private ?\DateTimeInterface $endedAt = null;
 
     /**
-     * Duration in seconds between the start and end times
+     * Duration in milliseconds between the start and end times
      *
-     * @ORM\Column(nullable=true)
+     * @ORM\Column(nullable=true, options={"unsigned":true})
      */
-    #[ORM\Column(nullable: true)]
+    #[ORM\Column(nullable: true, options: ['unsigned' => true])]
     private ?int $duration = null;
 
     /**
@@ -132,7 +132,24 @@ trait ProcessTrait
 
     public function getDurationAsString(): ?string
     {
-        return DateUtils::secondsToString($this->duration);
+        return DateUtils::millisecondsToString($this->duration);
+    }
+
+    public function getDurationSeconds(): ?int
+    {
+        if ($this->getDuration() === null) {
+            return null;
+        }
+
+        return $this->getDuration() / 1000;
+    }
+
+    /**
+     * Variant to use for process where printing milliseconds doesn't matter
+     */
+    public function getDurationSecondsAsString(): ?string
+    {
+        return DateUtils::secondsToString($this->getDurationSeconds());
     }
 
     public function setDuration(?int $duration): static

--- a/src/Monitoring/ProcessMonitor.php
+++ b/src/Monitoring/ProcessMonitor.php
@@ -27,7 +27,7 @@ class ProcessMonitor
     {
         $endedAt = new \DateTime();
         $process->setEndedAt($endedAt);
-        $process->setDuration($endedAt->getTimestamp() - $process->getStartedAt()->getTimestamp());
+        $process->setDuration((int) $endedAt->format('Uv') - (int) $process->getStartedAt()->format('Uv'));
         if ($isSuccess) {
             $process->setStatus(ProcessStatusEnum::SUCCESS);
         } else {

--- a/src/Utils/DateUtils.php
+++ b/src/Utils/DateUtils.php
@@ -580,4 +580,24 @@ class DateUtils
 
         return trim($toReturn);
     }
+
+    public static function millisecondsToString(?int $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+        $toReturn = self::secondsToString($value / 1000); // We reduce it to the seconds to benefit from secondsToString
+        if ($value > 60000) { // We act that printing the number of ms is only relevant if the $value is under a minute.
+            return $toReturn;
+        } elseif ($value < 1000) { // If inferior to 1 second we remove the '0s'
+            $toReturn = '';
+        }
+
+        $milliseconds = $value % 1000;
+        if ($toReturn === '' || $milliseconds !== 0) {
+            $toReturn .= " {$milliseconds}ms";
+        }
+
+        return trim($toReturn);
+    }
 }

--- a/tests/Utils/DateUtilsTest.php
+++ b/tests/Utils/DateUtilsTest.php
@@ -1318,11 +1318,35 @@ class DateUtilsTest extends TestCase
             '0 seconds' => ['0s', 0],
             '10 seconds' => ['10s', 10],
             '1 minutes' => ['1m', 60],
-            '1 minutes and 30 secondes' => ['1m 30s', 90],
+            '1 minutes and 30 seconds' => ['1m 30s', 90],
             '1 hours' => ['1h', 3600],
             '1 hours 15 minutes' => ['1h 15m', 4500],
-            '1 hours 1 minutes and 1 secondes' => ['1h 1m 1s', 3661],
+            '1 hours 1 minutes and 1 seconds' => ['1h 1m 1s', 3661],
             '3 hours' => ['3h', 10800],
+        ];
+    }
+
+    /**
+     * @dataProvider millisecondsToStringProvider
+     */
+    public function testMillisecondsToString(?string $expected, ?int $value): void
+    {
+        $this->assertEquals($expected, DateUtils::millisecondsToString($value));
+    }
+
+    public function millisecondsToStringProvider(): array
+    {
+        return [
+            'null value' => [null, null],
+            '0 milliseconds' => ['0ms', 0],
+            '12 milliseconds' => ['12ms', 12],
+            '123 milliseconds' => ['123ms', 123],
+            '1000 milliseconds to 1 second' => ['1s', 1000],
+            'exact seconds and no milliseconds' => ['7s', 7000],
+            'seconds and milliseconds' => ['26s 457ms', 26457],
+            '1 minute' => ['1m', 60000],
+            '1 minute and some milliseconds' => ['1m', 60123],
+            // all timing cases above falls into the testSecondsToString
         ];
     }
 }


### PR DESCRIPTION
\+ DateUtils::millisecondsToString