### PR TITLE
Allow doctrine fixture bundle v4 & Change composer logical OR syntax to `||` to follow composer doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG for 1.x
 
 ### Fixed
 - Remove doctrine dbal option `use_savepoints` witch is deleted with option true by default
+- Remove doctrine orm option `auto_generate_proxy_classes` witch is deleted with option true by default
 
 ## v1.18.0 - (2026-05-15)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 CHANGELOG for 1.x
 ===================
+## v1.18.1 - (2026-05-19)
+### Added
+- Allow `doctrine/doctrine-fixtures-bundle` v4
+
+### Changed
+- Change composer logical OR syntax to `||` to follow composer doc
 
 ## v1.18.0 - (2026-05-15)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ CHANGELOG for 1.x
 ### Changed
 - Change composer logical OR syntax to `||` to follow composer doc
 
+### Fixed
+- Remove doctrine dbal option `use_savepoints` witch is deleted with option true by default
+
 ## v1.18.0 - (2026-05-15)
 ### Added
 - Allow orm 3

--- a/composer.json
+++ b/composer.json
@@ -14,25 +14,25 @@
   "require": {
     "php": "^8.1",
     "doctrine/doctrine-fixtures-bundle": "^3.4 || ^4.0",
-    "doctrine/orm": "^2.19|^3.0",
-    "egulias/email-validator": "^3.0|^4.0",
+    "doctrine/orm": "^2.19 || ^3.0",
+    "egulias/email-validator": "^3.0 || ^4.0",
     "nelmio/security-bundle": "^2.8 || ^3.0",
     "sentry/sentry-symfony": "^4.9 || ^5.1",
     "symfony/apache-pack": "^1.0",
-    "symfony/form": "^5.4|^6.2|^7.4",
-    "symfony/framework-bundle": "^5.4|^6.2|^7.4",
-    "symfony/security-bundle": "^5.4|^6.2|^7.4",
-    "symfony/translation": "^5.4|^6.2|^7.4",
-    "symfony/http-client": "^5.4|^6.2|^7.4",
+    "symfony/form": "^5.4 || ^6.2 || ^7.4",
+    "symfony/framework-bundle": "^5.4 || ^6.2 || ^7.4",
+    "symfony/security-bundle": "^5.4 || ^6.2 || ^7.4",
+    "symfony/translation": "^5.4 || ^6.2 || ^7.4",
+    "symfony/http-client": "^5.4 || ^6.2 || ^7.4",
     "theofidry/alice-data-fixtures": "^1.5"
   },
   "require-dev": {
     "smartbooster/standard-bundle": "^1.0",
     "symfony/flex": "^2",
-    "symfony/phpunit-bridge": "^5.4|^6.2|^7.0",
-    "symfony/runtime": "^5.4|^6.2|^7.4",
-    "symfony/twig-bundle": "^5.4|^6.2|^7.4",
-    "symfony/var-exporter": "^5.4|^6.2|^7.4"
+    "symfony/phpunit-bridge": "^5.4 || ^6.2 || ^7.0",
+    "symfony/runtime": "^5.4 || ^6.2 || ^7.4",
+    "symfony/twig-bundle": "^5.4 || ^6.2 || ^7.4",
+    "symfony/var-exporter": "^5.4 || ^6.2 || ^7.4"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.1",
-    "doctrine/doctrine-fixtures-bundle": "^3.4",
+    "doctrine/doctrine-fixtures-bundle": "^3.4 || ^4.0",
     "doctrine/orm": "^2.19|^3.0",
     "egulias/email-validator": "^3.0|^4.0",
     "nelmio/security-bundle": "^2.8 || ^3.0",

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -3,5 +3,4 @@ doctrine:
   dbal:
     driver:   pdo_sqlite
   orm:
-    auto_generate_proxy_classes: true
     auto_mapping: true

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -2,7 +2,6 @@
 doctrine:
   dbal:
     driver:   pdo_sqlite
-    use_savepoints: true
   orm:
     auto_generate_proxy_classes: true
     auto_mapping: true


### PR DESCRIPTION
- Remove doctrine dbal option `use_savepoints` witch is deleted with option true by default
- Remove doctrine orm option `auto_generate_proxy_classes` witch is deleted with option true by default